### PR TITLE
Update turkish-dictionary-api

### DIFF
--- a/bin/turkish-dictionary-api
+++ b/bin/turkish-dictionary-api
@@ -7,4 +7,4 @@ var command = require("new-command")({
 
 require("default-debug")('circle:server,api');
 
-require('../').start(command.port || 3000, command.hostname || '0.0.0.0');
+require('../').start(command.port || 3000, command.hostname || '127.0.0.1');


### PR DESCRIPTION
Default hostname value does not work with windows
